### PR TITLE
Removing the unused parameter 'url'

### DIFF
--- a/washer-done/functions/index.js
+++ b/washer-done/functions/index.js
@@ -315,7 +315,7 @@ exports.reportstate = functions.database.ref('{deviceId}').onWrite((event) => {
     });
 });
 
-const reportState = (url, data, jwt) => {
+const reportState = (data, jwt) => {
   console.log(JSON.stringify(data));
   const {google} = require('googleapis');
   const https = require('https');


### PR DESCRIPTION
Currently the function call made to `reportState()` doesn't contain parameter 'url':

![image](https://user-images.githubusercontent.com/1381195/42671634-933319ee-8693-11e8-8ae0-b45320a22139.png)

while the signature is `const reportState = (url, data, jwt) => ......`
